### PR TITLE
Raise totalEntitySizeLimit for dictionary XML parsing

### DIFF
--- a/cfml.dictionary/src/main/java/cfml/dictionary/SyntaxDictionary.java
+++ b/cfml.dictionary/src/main/java/cfml/dictionary/SyntaxDictionary.java
@@ -555,7 +555,12 @@ public abstract class SyntaxDictionary {
 		factory.setNamespaceAware(false);
 		factory.setValidating(false);
 		final XMLReader xmlReader = factory.newSAXParser().getXMLReader();
-		
+		// The dictionary XML reuses a handful of shared attribute-group entities (event handlers,
+		// core/lang attributes etc.) across ~90 tag definitions, which legitimately accumulates
+		// past newer JDKs' tightened jdk.xml.totalEntitySizeLimit default - raise it for this
+		// parser instance only.
+		xmlReader.setProperty("http://www.oracle.com/xml/jaxp/properties/totalEntitySizeLimit", "10000000");
+
 		// setup the content handler and give it the maps for tags and functions
 		xmlReader.setContentHandler(new DictionaryContentHandler(syntaxelements, functions, scopeVars, scopes));
 		xmlReader.parse(input);


### PR DESCRIPTION
## Summary
- Fixes #2 — `SyntaxDictionary.loadDictionary()` throws `SAXParseException (JAXP00010004)` on JDK 25, because `html.xml`'s shared attribute-group entities (event handlers, core/lang attributes) are `&entity;`-referenced 335 times across ~90 tag definitions, and the accumulated expansion crosses JDK 25's tightened default for `jdk.xml.totalEntitySizeLimit`. JDK 21 doesn't hit this.
- Sets the limit explicitly on this one `XMLReader` instance (`http://www.oracle.com/xml/jaxp/properties/totalEntitySizeLimit`), so no other XML parsing in a consuming application is affected.

## Test plan
- [x] Reproduced the exact `JAXP00010004` failure in isolation with a small synthetic DTD (repeated small entity, same shape as `html.xml`'s pattern) on JDK 25, confirmed it disappears with the property set and the parser instance without it still fails as before (proving the fix is scoped, not a JVM-wide change).
- [ ] Maintainer to confirm dictionary loading still succeeds end-to-end via this repo's own test/build (this repo's Gradle 6.9.4 wrapper isn't compatible with the JDKs available where this PR was authored).