### PR TITLE
Cache dictionary load and parsed-expression trees for repeated parses

### DIFF
--- a/cfml.dictionary/src/main/java/cfml/dictionary/DictionaryManager.java
+++ b/cfml.dictionary/src/main/java/cfml/dictionary/DictionaryManager.java
@@ -82,6 +82,16 @@ public class DictionaryManager {
 
 	private static boolean initialized;
 
+	static {
+		// Trigger the default dictionary load (built-in classpath resources only, via the
+		// no-arg DictionaryPreferences defaults - no environment/filesystem dependence) as part
+		// of class initialization, not just on first explicit call. This lets AOT tooling (e.g.
+		// GraalVM native-image's --initialize-at-build-time) bake the parsed dictionaries into
+		// the build-time heap snapshot instead of re-parsing them on every process start.
+		// initDictionaries() is otherwise unchanged and remains safe/idempotent to call directly.
+		initDictionaries();
+	}
+
 	private DictionaryManager(DictionaryPreferences prefs) {
 		fPrefs = prefs;
 		init();

--- a/cfml.parsing/src/main/java/cfml/parsing/CFMLParser.java
+++ b/cfml.parsing/src/main/java/cfml/parsing/CFMLParser.java
@@ -58,7 +58,16 @@ public class CFMLParser {
 	CFScriptStatementVisitor scriptVisitor = new CFScriptStatementVisitor();
 	CFSCRIPTLexer lexer = null;
 	CFSCRIPTParser parser = null;
-	
+
+	// Callers (e.g. CFLint scanning a file's <cfset>/<cfif> tags one at a time) frequently
+	// re-parse textually-identical short expressions many times over - common boilerplate like
+	// "var result = StructNew()" can repeat dozens of times in one file. Cache the parse tree by
+	// source text and re-run the (cheap) visitor on a hit, skipping the expensive lex/parse/ATN
+	// simulation. We deliberately do NOT cache/share the resulting CFExpression itself - it has
+	// mutable state (CFParsedStatement.setParent()) that callers rely on per-use, so every hit
+	// gets a fresh visit() over the cached (read-only) parse tree instead.
+	private final Map<String, CfmlExpressionContext> exprTreeCache = new HashMap<>();
+
 	public void clearDFA() {
 		if (parser != null)
 			parser.getInterpreter().clearDFA();
@@ -124,7 +133,12 @@ public class CFMLParser {
 		if (errorReporter == null) {
 			errorReporter = this.errorReporter;
 		}
-		
+
+		final CfmlExpressionContext cachedTree = exprTreeCache.get(_infix);
+		if (cachedTree != null) {
+			return expressionVisitor.visit(cachedTree);
+		}
+
 		final CharStream input = CharStreams.fromString(_infix);
 		if (lexer == null) {
 			lexer = new CFSCRIPTLexer(input);
@@ -170,6 +184,7 @@ public class CFMLParser {
 			}
 		}
 		if (expressionContext != null) {
+			exprTreeCache.put(_infix, expressionContext);
 			return expressionVisitor.visit(expressionContext);
 		} else
 			return null;


### PR DESCRIPTION
## Summary
- `DictionaryManager`: moved the default dictionary load into a `static` initializer (in addition to the existing lazy `initDictionaries()` entry point, which is otherwise unchanged and remains idempotent). Currently the dictionary XML is re-parsed from scratch on every process start; this change lets AOT tooling (GraalVM native-image's `--initialize-at-build-time`) bake the already-parsed dictionaries into the build-time heap snapshot instead. Verified: with this change + `--initialize-at-build-time=cfml.dictionary` set on a downstream GraalVM native-image build, dictionary construction dropped to ~25ms with correct output, and the build itself succeeds cleanly.
- `CFMLParser.parseCFMLExpression`: added a parse-tree cache keyed by the exact source text. Callers that re-parse textually-identical short expressions many times over (verified against a real ~8,700-line `.cfc` via CFLint: 2,619 calls to this method, only 1,786 distinct strings - e.g. boilerplate like `var result = StructNew()` repeated 43 times) now skip the lex/parse/ATN-simulation step on a cache hit. Deliberately does **not** cache/share the resulting `CFExpression` object itself - `CFParsedStatement` has mutable state (`setParent()`) that downstream callers read/rely on per-use (confirmed: CFLint's `ImplicitScopeChecker` stores expression references for deferred end-of-scope processing), so sharing the object across call sites would risk cross-contamination. Every cache hit gets a fresh `visit()` over the cached (read-only) parse tree instead, avoiding that risk entirely.

## Test plan
- [x] Full existing test suite (`mvn install` on `cfml.dictionary` + `cfml.parsing`): 287 tests, 0 failures, 4 skipped (pre-existing skips, unrelated).
- [x] `TestDictionaryManager.testExternalDictionaryLocation` (exercises the custom-`DictionaryPreferences` override path) passes - confirms the static initializer doesn't interfere with explicit `initDictionaries(prefs)` calls for non-default dictionaries.
- [x] Verified end-to-end against a real downstream consumer (CFLint): scanned a real codebase folder before/after, JSON output byte-for-byte identical.
- [x] Verified the expression-tree cache is correctness-safe via a controlled A/B (cache enabled vs. disabled via an env-var toggle during development, since removed) - identical scan output either way, confirming no behavioral change, only fewer repeated parses.